### PR TITLE
Add Local State backup and restore support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [lcandy2]

--- a/README.md
+++ b/README.md
@@ -31,9 +31,15 @@ Tiny Python helper that enables Chrome's built-in AI features by patching your l
 2. Install deps: `python -m pip install psutil`.
 3. Run: `python main.py`.
 
+## ↩️ Restore / Undo
+- Before the first patch, the script creates a backup next to Chrome's `Local State` file: `Local State.enable-chrome-ai.bak`.
+- To restore the original file, run: `uv run main.py --restore` or `python main.py --restore`.
+- If you manage backups yourself, run with `--no-backup` to skip backup creation.
+
 ## 🔧 What Happens
 - Finds Chrome user data for Stable/Canary/Dev/Beta on Windows, macOS, and Linux.
 - Kills top-level Chrome processes to avoid file locks, then brings them back.
+- Creates a `Local State.enable-chrome-ai.bak` backup before the first patch.
 - Sets all `is_glic_eligible` to `true` in `Local State` (recursive search).
 - Sets `variations_country` to `"us"` in `Local State`.
 - Sets `variations_permanent_consistency_country` to `["<version>", "us"]` in `Local State`.
@@ -49,6 +55,9 @@ Tiny Python helper that enables Chrome's built-in AI features by patching your l
 - The script writes to your existing Chrome profile; back up `User Data` if you want a safety net.
 - Run as the same OS user who owns the Chrome profile to ensure write access.
 - Not affiliated with Google—use at your own risk.
+
+## 💖 Support
+If this saved you from reinstalling Chrome or wiping profile data, you can support maintenance through [GitHub Sponsors](https://github.com/sponsors/lcandy2). Small one-time sponsorships help cover testing across Chrome channels and platforms.
 
 ## 📜 License
 Please credit this project when reposting or creating derivative works.

--- a/README.zh.md
+++ b/README.zh.md
@@ -30,9 +30,15 @@
 2. 安装依赖：`python -m pip install psutil`。
 3. 运行：`python main.py`。
 
+## ↩️ 恢复 / 撤销
+- 首次修改前，脚本会在 Chrome 的 `Local State` 旁创建备份：`Local State.enable-chrome-ai.bak`。
+- 如需恢复原始文件，运行：`uv run main.py --restore` 或 `python main.py --restore`。
+- 如果你已经自行管理备份，可以加 `--no-backup` 跳过备份创建。
+
 ## 🔧 做了什么
 - 自动定位 Windows / macOS / Linux 上的 Chrome Stable / Canary / Dev / Beta 用户数据目录。
 - 关闭顶层 Chrome 进程以避免文件锁，再在补丁后恢复。
+- 首次修改前创建 `Local State.enable-chrome-ai.bak` 备份。
 - 在 `Local State` 中递归查找并将所有 `is_glic_eligible` 设为 `true`。
 - 在 `Local State` 中将 `variations_country` 设为 `"us"`。
 - 在 `Local State` 中将 `variations_permanent_consistency_country` 设为 `["<版本号>", "us"]`。
@@ -48,6 +54,9 @@
 - 脚本会修改现有 Chrome 配置，如需保险请先备份 `User Data`。
 - 使用拥有该 Chrome 配置的同一系统用户运行，确保有写入权限。
 - 与 Google 无关，风险自担。
+
+## 💖 支持项目
+如果这个脚本帮你省下了重装 Chrome 或清空配置的时间，可以通过 [GitHub Sponsors](https://github.com/sponsors/lcandy2) 小额支持维护。一次性赞助也很有帮助，可以支持我继续测试更多 Chrome 渠道和平台。
 
 ## 📜 许可
 转载或基于本研究二次创作需要注明来源。

--- a/main.py
+++ b/main.py
@@ -1,9 +1,31 @@
 import os
 import sys
 import json
+import shutil
+import argparse
 import subprocess
 
 import psutil
+
+
+BACKUP_SUFFIX = '.enable-chrome-ai.bak'
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Patch Chrome local profile data to enable built-in AI features.'
+    )
+    parser.add_argument(
+        '--restore',
+        action='store_true',
+        help='Restore Local State from the backup created before the first patch.',
+    )
+    parser.add_argument(
+        '--no-backup',
+        action='store_true',
+        help='Patch without creating a Local State backup.',
+    )
+    return parser.parse_args()
 
 
 def get_version_and_user_data_path():
@@ -40,23 +62,62 @@ def get_version_and_user_data_path():
     raise Exception('Unsupported platform %s' % sys.platform)
 
 
+def get_local_state_file(user_data_path):
+    return os.path.join(user_data_path, 'Local State')
+
+
+def get_backup_file(local_state_file):
+    return local_state_file + BACKUP_SUFFIX
+
+
+def backup_local_state(local_state_file):
+    backup_file = get_backup_file(local_state_file)
+    if os.path.exists(backup_file):
+        print('Backup already exists', backup_file)
+        return
+    shutil.copy2(local_state_file, backup_file)
+    print('Created backup', backup_file)
+
+
+def restore_local_state(user_data_path):
+    local_state_file = get_local_state_file(user_data_path)
+    backup_file = get_backup_file(local_state_file)
+    if not os.path.exists(backup_file):
+        print('No backup found', backup_file)
+        return False
+    shutil.copy2(backup_file, local_state_file)
+    print('Restored Local State from backup', backup_file)
+    return True
+
+
+def is_top_level_chrome_process(process):
+    name = process.name()
+    if sys.platform == 'darwin':
+        return name.startswith('Google Chrome')
+    if os.path.splitext(name)[0] != 'chrome':
+        return False
+    if not process.is_running():
+        return False
+
+    parent = process.parent()
+    if parent is None:
+        return True
+    try:
+        return parent.name() != name
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return True
+
+
 def shutdown_chrome():
     terminated_chromes = set()
     for process in psutil.process_iter():
         try:
-            if sys.platform == 'darwin':
-                if not process.name().startswith('Google Chrome'):
-                    continue
-            elif os.path.splitext(process.name())[0] != 'chrome':
-                continue
-            elif not process.is_running():
-                continue
-            elif process.parent() is not None and process.parent().name() == process.name():
+            if not is_top_level_chrome_process(process):
                 continue
             location = process.exe()
             process.kill()
             terminated_chromes.add(location)
-        except psutil.NoSuchProcess:
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             pass
     return terminated_chromes
 
@@ -88,11 +149,14 @@ def set_all_is_glic_eligible(obj):
     return modified
 
 
-def patch_local_state(user_data_path, last_version):
-    local_state_file = os.path.join(user_data_path, 'Local State')
+def patch_local_state(user_data_path, last_version, create_backup=True):
+    local_state_file = get_local_state_file(user_data_path)
     if not os.path.exists(local_state_file):
         print('Failed to patch Local State. File not found', local_state_file)
         return
+
+    if create_backup:
+        backup_local_state(local_state_file)
 
     with open(local_state_file, 'r', encoding='utf-8') as fp:
         local_state = json.load(fp)
@@ -130,6 +194,7 @@ def patch_local_state(user_data_path, last_version):
 
 
 def main():
+    args = parse_args()
     version_and_user_data_path = get_version_and_user_data_path()
     if len(version_and_user_data_path) == 0:
         raise Exception('No available user data path found')
@@ -138,14 +203,18 @@ def main():
     if len(terminated_chromes) > 0:
         print('Shutdown Chrome')
 
-    for version, user_data_path in version_and_user_data_path.items():
-        last_version = get_last_version(user_data_path)
-        if last_version is None:
-            print('Failed to get version. File not found', os.path.join(user_data_path, 'Last Version'))
-            continue
-        main_version = int(last_version.split('.')[0])
-        print('Patching Chrome', version, last_version, '"'+user_data_path+'"')
-        patch_local_state(user_data_path, last_version)
+    if args.restore:
+        for version, user_data_path in version_and_user_data_path.items():
+            print('Restoring Chrome', version, '"'+user_data_path+'"')
+            restore_local_state(user_data_path)
+    else:
+        for version, user_data_path in version_and_user_data_path.items():
+            last_version = get_last_version(user_data_path)
+            if last_version is None:
+                print('Failed to get version. File not found', os.path.join(user_data_path, 'Last Version'))
+                continue
+            print('Patching Chrome', version, last_version, '"'+user_data_path+'"')
+            patch_local_state(user_data_path, last_version, create_backup=not args.no_backup)
 
     if len(terminated_chromes) > 0:
         print('Restart Chrome')
@@ -157,4 +226,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
## Summary
- create a `Local State.enable-chrome-ai.bak` backup before patching Chrome profile data
- add `--restore` to restore from the backup and `--no-backup` for users managing backups themselves
- harden Chrome process shutdown against psutil race conditions
- document restore/undo steps in English and Chinese
- add GitHub Sponsors funding metadata

## Verification
- `uv run python -m py_compile main.py`
- `uv run python main.py --help`
- temporary Local State behavior test for backup, patch, and restore