### PR TITLE
Update Glic enablement patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Enable Gemini in Chrome, AI Powered History search, and DevTools AI Innovations 
 
 <img width="512" alt="Google Chrome Gemini in Chrome" src="https://github.com/user-attachments/assets/a88c56a7-f20b-432a-926c-0184194225b4" />
 
-Tiny Python helper that enables Chrome's built-in AI features by patching your local profile data (`variations_country`, `variations_permanent_consistency_country`, and `is_glic_eligible`)—no browser flags required.
+Tiny Python helper that enables Chrome's built-in AI features by patching your local Chrome state and profile preferences, then restarting Chrome with the launch args needed by current Glic checks.
 
 ## ✅ Requirements
 - Python `3.13+` (see `.python-version` / `pyproject.toml`)
@@ -37,12 +37,18 @@ Tiny Python helper that enables Chrome's built-in AI features by patching your l
 - Sets all `is_glic_eligible` to `true` in `Local State` (recursive search).
 - Sets `variations_country` to `"us"` in `Local State`.
 - Sets `variations_permanent_consistency_country` to `["<version>", "us"]` in `Local State`.
-- Restarts any Chrome builds that were running before the patch.
+- Sets `variations_permanent_overridden_country` to `"us"` in `Local State`.
+- Sets safe-seed country values (`variations_safe_seed_permanent_consistency_country` and `variations_safe_seed_session_consistency_country`) to `"us"` in `Local State`.
+- Adds current Glic entries to `browser.enabled_labs_experiments` while preserving existing flags.
+- Patches each real profile `Preferences` file with current Glic/Gemini prefs: `sync.glic_rollout_eligibility`, `browser.gemini_settings`, and `glic.pinned_to_tabstrip`.
+- Restarts any Chrome builds that were running before the patch with `--variations-override-country=us`, `--glic-dev`, and `--disable-features=GlicUseSessionCountryForFiltering`.
 
 ## ⚠️ Caveats / Known Limitations
 - The script expects `User Data/Local State` to exist; if it's missing, the run can fail (launch Chrome once to generate it).
 - Chrome restart only happens if the executable path can be detected from running processes.
-- On macOS, process detection is name-based (`Google Chrome*`) and may terminate more than just the "top-level" app process.
+- If Chrome was not running, start Chrome manually with the launch args printed by the script.
+- Gemini in Chrome can still be blocked by Google account eligibility, sign-in state, enterprise policy, account region, or server-side rollout checks.
+- On macOS, process detection targets known top-level Chrome app process names.
 - On Linux, process detection expects an executable name of `chrome`; if your build uses a different name, Chrome may not be closed (and files may remain locked).
 
 ## 🛟 Notes

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,7 +10,7 @@
 
 <img width="512" alt="Google Chrome Gemini in Chrome" src="https://github.com/user-attachments/assets/a88c56a7-f20b-432a-926c-0184194225b4" />
 
-轻量 Python 脚本，通过修改本地 Chrome 配置（`variations_country`、`variations_permanent_consistency_country` 和 `is_glic_eligible`）启用浏览器内置 AI 功能，无需额外开关。
+轻量 Python 脚本，通过修改本地 Chrome 状态和 profile 偏好设置，并用当前 Glic 检查需要的启动参数重启 Chrome 来启用浏览器内置 AI 功能。
 
 ## ✅ 环境要求
 - Python `3.13+`（见 `.python-version` / `pyproject.toml`）
@@ -36,12 +36,18 @@
 - 在 `Local State` 中递归查找并将所有 `is_glic_eligible` 设为 `true`。
 - 在 `Local State` 中将 `variations_country` 设为 `"us"`。
 - 在 `Local State` 中将 `variations_permanent_consistency_country` 设为 `["<版本号>", "us"]`。
-- 重启补丁前已运行的 Chrome 版本。
+- 在 `Local State` 中将 `variations_permanent_overridden_country` 设为 `"us"`。
+- 在 `Local State` 中将 safe-seed 国家值（`variations_safe_seed_permanent_consistency_country` 和 `variations_safe_seed_session_consistency_country`）设为 `"us"`。
+- 在保留已有 flags 的同时，把当前 Glic 相关项追加到 `browser.enabled_labs_experiments`。
+- 遍历真实 profile 的 `Preferences`，写入当前 Glic/Gemini 入口相关偏好：`sync.glic_rollout_eligibility`、`browser.gemini_settings` 和 `glic.pinned_to_tabstrip`。
+- 用 `--variations-override-country=us`、`--glic-dev` 和 `--disable-features=GlicUseSessionCountryForFiltering` 重启补丁前已运行的 Chrome 版本。
 
 ## ⚠️ 已知限制 / 注意事项
 - 脚本假设 `User Data/Local State` 已存在；若缺失可能直接失败（可先启动一次 Chrome 生成配置）。
 - 只有在能从进程信息中取到可执行文件路径时，脚本才会自动重启 Chrome。
-- macOS 上按进程名（`Google Chrome*`）识别，可能会终止不止"顶层"应用进程。
+- 如果运行脚本时 Chrome 没有启动，请使用脚本打印出的启动参数手动启动 Chrome。
+- Gemini in Chrome 仍可能被 Google 账号资格、登录状态、企业策略、账号地区或服务端灰度规则阻止。
+- macOS 上仅按已知顶层 Chrome 应用进程名识别。
 - Linux 上按可执行文件名 `chrome` 识别；若你的发行版/安装方式使用其他名字，可能不会关闭 Chrome（从而仍可能有文件锁）。
 
 ## 🛟 注意

--- a/main.py
+++ b/main.py
@@ -6,6 +6,35 @@ import subprocess
 import psutil
 
 
+TARGET_COUNTRY = 'us'
+CHROME_RESTART_ARGS = (
+    f'--variations-override-country={TARGET_COUNTRY}',
+    '--glic-dev',
+    '--disable-features=GlicUseSessionCountryForFiltering',
+)
+FORCED_LABS_EXPERIMENTS = (
+    'glic@1',
+    'glic-actor@1',
+    'glic-entrypoint-variations@1',
+)
+PROFILE_PREF_PATCHES = {
+    ('browser', 'gemini_settings'): 0,
+    ('glic', 'pinned_to_tabstrip'): True,
+    ('sync', 'glic_rollout_eligibility'): True,
+}
+MACOS_CHROME_PROCESS_NAMES = {
+    'Google Chrome',
+    'Google Chrome Canary',
+    'Google Chrome Dev',
+    'Google Chrome Beta',
+}
+EXCLUDED_PROFILE_DIRS = {
+    'CertificateRevocation',
+    'Guest Profile',
+    'System Profile',
+}
+
+
 def get_version_and_user_data_path():
     os_and_user_data_paths = {
         'win32': {
@@ -42,10 +71,11 @@ def get_version_and_user_data_path():
 
 def shutdown_chrome():
     terminated_chromes = set()
+    processes_to_wait = []
     for process in psutil.process_iter():
         try:
             if sys.platform == 'darwin':
-                if not process.name().startswith('Google Chrome'):
+                if process.name() not in MACOS_CHROME_PROCESS_NAMES:
                     continue
             elif os.path.splitext(process.name())[0] != 'chrome':
                 continue
@@ -55,10 +85,34 @@ def shutdown_chrome():
                 continue
             location = process.exe()
             process.kill()
+            processes_to_wait.append(process)
             terminated_chromes.add(location)
         except psutil.NoSuchProcess:
             pass
+    psutil.wait_procs(processes_to_wait, timeout=10)
     return terminated_chromes
+
+
+def get_macos_app_path(executable_path):
+    app_suffix = '.app'
+    app_index = executable_path.find(app_suffix)
+    if app_index == -1:
+        return None
+    return executable_path[:app_index + len(app_suffix)]
+
+
+def restart_chrome(chrome):
+    restart_args = list(CHROME_RESTART_ARGS)
+    print('Start Chrome with args', ' '.join(restart_args))
+    if sys.platform == 'darwin':
+        app_path = get_macos_app_path(chrome)
+        if app_path:
+            subprocess.Popen(
+                ['open', app_path, '--args', *restart_args],
+                stderr=subprocess.DEVNULL,
+            )
+            return
+    subprocess.Popen([chrome, *restart_args], stderr=subprocess.DEVNULL)
 
 
 def get_last_version(user_data_path):
@@ -66,7 +120,7 @@ def get_last_version(user_data_path):
     if not os.path.exists(last_version_file):
         return None
     with open(last_version_file, 'r', encoding='utf-8') as fp:
-        return fp.read()
+        return fp.read().strip()
 
 
 def set_all_is_glic_eligible(obj):
@@ -74,7 +128,7 @@ def set_all_is_glic_eligible(obj):
     modified = False
     if isinstance(obj, dict):
         for key, value in obj.items():
-            if key == 'is_glic_eligible' and value != True:
+            if key == 'is_glic_eligible' and value is not True:
                 obj[key] = True
                 modified = True
             elif isinstance(value, (dict, list)):
@@ -85,6 +139,91 @@ def set_all_is_glic_eligible(obj):
             if isinstance(item, (dict, list)):
                 if set_all_is_glic_eligible(item):
                     modified = True
+    return modified
+
+
+def set_nested_value(obj, path, value):
+    current = obj
+    for key in path[:-1]:
+        next_obj = current.get(key)
+        if not isinstance(next_obj, dict):
+            next_obj = {}
+            current[key] = next_obj
+        current = next_obj
+
+    key = path[-1]
+    if current.get(key) == value:
+        return False
+    current[key] = value
+    return True
+
+
+def get_profile_preference_files(user_data_path, local_state):
+    profile_dirs = []
+    info_cache = local_state.get('profile', {}).get('info_cache', {})
+    if isinstance(info_cache, dict):
+        profile_dirs.extend(info_cache.keys())
+
+    try:
+        for profile_dir in os.listdir(user_data_path):
+            preference_file = os.path.join(user_data_path, profile_dir, 'Preferences')
+            if os.path.isfile(preference_file):
+                profile_dirs.append(profile_dir)
+    except FileNotFoundError:
+        return []
+
+    preference_files = []
+    seen = set()
+    for profile_dir in profile_dirs:
+        if profile_dir in EXCLUDED_PROFILE_DIRS or profile_dir in seen:
+            continue
+        preference_file = os.path.join(user_data_path, profile_dir, 'Preferences')
+        if os.path.isfile(preference_file):
+            preference_files.append(preference_file)
+            seen.add(profile_dir)
+    return preference_files
+
+
+def patch_profile_preferences(user_data_path, local_state):
+    modified_files = 0
+    for preference_file in get_profile_preference_files(user_data_path, local_state):
+        try:
+            with open(preference_file, 'r', encoding='utf-8') as fp:
+                preferences = json.load(fp)
+        except (json.JSONDecodeError, OSError) as error:
+            print('Failed to patch Preferences.', preference_file, error)
+            continue
+
+        modified = False
+        for path, value in PROFILE_PREF_PATCHES.items():
+            if set_nested_value(preferences, path, value):
+                modified = True
+                print('Patched', '.'.join(path), 'in', preference_file)
+
+        if modified:
+            with open(preference_file, 'w', encoding='utf-8') as fp:
+                json.dump(preferences, fp)
+            modified_files += 1
+
+    return modified_files
+
+
+def append_forced_labs_experiments(local_state):
+    browser = local_state.get('browser')
+    if not isinstance(browser, dict):
+        browser = {}
+        local_state['browser'] = browser
+
+    experiments = browser.get('enabled_labs_experiments')
+    if not isinstance(experiments, list):
+        experiments = []
+        browser['enabled_labs_experiments'] = experiments
+
+    modified = False
+    for experiment in FORCED_LABS_EXPERIMENTS:
+        if experiment not in experiments:
+            experiments.append(experiment)
+            modified = True
     return modified
 
 
@@ -105,21 +244,35 @@ def patch_local_state(user_data_path, last_version):
         print('Patched is_glic_eligible')
 
     # 2. Set variations_country to "us" (root level)
-    if local_state.get('variations_country') != 'us':
-        local_state['variations_country'] = 'us'
+    if local_state.get('variations_country') != TARGET_COUNTRY:
+        local_state['variations_country'] = TARGET_COUNTRY
         modified = True
         print('Patched variations_country')
 
-    # 3. Set variations_permanent_consistency_country[0] to last_version, [1] to "us" (root level)
-    if 'variations_permanent_consistency_country' in local_state:
-        if isinstance(local_state['variations_permanent_consistency_country'], list) and \
-           len(local_state['variations_permanent_consistency_country']) >= 2:
-            if local_state['variations_permanent_consistency_country'][0] != last_version or \
-               local_state['variations_permanent_consistency_country'][1] != 'us':
-                local_state['variations_permanent_consistency_country'][0] = last_version
-                local_state['variations_permanent_consistency_country'][1] = 'us'
-                modified = True
-                print('Patched variations_permanent_consistency_country')
+    # 3. Patch both permanent and session country values used by current Glic filtering.
+    target_permanent_country = [last_version, TARGET_COUNTRY]
+    if local_state.get('variations_permanent_consistency_country') != target_permanent_country:
+        local_state['variations_permanent_consistency_country'] = target_permanent_country
+        modified = True
+        print('Patched variations_permanent_consistency_country')
+
+    if local_state.get('variations_permanent_overridden_country') != TARGET_COUNTRY:
+        local_state['variations_permanent_overridden_country'] = TARGET_COUNTRY
+        modified = True
+        print('Patched variations_permanent_overridden_country')
+
+    for key in (
+        'variations_safe_seed_permanent_consistency_country',
+        'variations_safe_seed_session_consistency_country',
+    ):
+        if local_state.get(key) != TARGET_COUNTRY:
+            local_state[key] = TARGET_COUNTRY
+            modified = True
+            print('Patched', key)
+
+    if append_forced_labs_experiments(local_state):
+        modified = True
+        print('Patched browser.enabled_labs_experiments')
 
     if modified:
         with open(local_state_file, 'w', encoding='utf-8') as fp:
@@ -127,6 +280,12 @@ def patch_local_state(user_data_path, last_version):
         print('Succeeded in patching Local State')
     else:
         print('No need to patch Local State')
+
+    patched_preferences = patch_profile_preferences(user_data_path, local_state)
+    if patched_preferences > 0:
+        print('Succeeded in patching Preferences', patched_preferences)
+    else:
+        print('No need to patch Preferences')
 
 
 def main():
@@ -143,18 +302,21 @@ def main():
         if last_version is None:
             print('Failed to get version. File not found', os.path.join(user_data_path, 'Last Version'))
             continue
-        main_version = int(last_version.split('.')[0])
         print('Patching Chrome', version, last_version, '"'+user_data_path+'"')
         patch_local_state(user_data_path, last_version)
 
     if len(terminated_chromes) > 0:
         print('Restart Chrome')
         for chrome in terminated_chromes:
-            subprocess.Popen([chrome], stderr=subprocess.DEVNULL)
+            restart_chrome(chrome)
+    else:
+        print(
+            'Chrome was not running. Start Chrome with:',
+            ' '.join(CHROME_RESTART_ARGS),
+        )
 
     input('Enter to continue...')
 
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
## Summary
- Patch additional Chrome Local State country fields used by current Glic checks
- Patch per-profile Gemini/Glic prefs so the tabstrip entry can appear
- Restart Chrome with the launch args needed for current Glic enablement checks
- Narrow macOS restart handling to top-level Chrome app processes

## Validation
- `uv run python -m py_compile main.py`
- Ran a temporary profile simulation covering Local State and Preferences patching
