### PR TITLE
feat: persist Chrome country overrides on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Tiny Python helper that enables Chrome's built-in AI features by patching your l
 3. Run the script: `uv run main.py`.
 4. Chrome will close while patching; after it restarts, press Enter to finish.
 
+To keep the US region persistent on macOS, install the scheduled LaunchAgent:
+
+```bash
+uv run main.py --install-persistence
+```
+
+It checks after installation, at login, and every Sunday at 04:00 (or after the
+next wake). It only restarts Chrome when the region or eligibility values have
+drifted. Remove it with `uv run main.py --remove-persistence`. Removing the
+LaunchAgent stops future checks but does not restore previous Chrome values.
+
 ## ⚡️ Quick Start (pip)
 1. Create and activate a venv.
 2. Install deps: `python -m pip install psutil`.
@@ -42,7 +53,8 @@ Tiny Python helper that enables Chrome's built-in AI features by patching your l
 ## ⚠️ Caveats / Known Limitations
 - The script expects `User Data/Local State` to exist; if it's missing, the run can fail (launch Chrome once to generate it).
 - Chrome restart only happens if the executable path can be detected from running processes.
-- On macOS, process detection is name-based (`Google Chrome*`) and may terminate more than just the "top-level" app process.
+- On macOS, process detection targets the known top-level Chrome app names and excludes helper processes.
+- Persistent mode depends on this checkout and its Python environment remaining at their current paths.
 - On Linux, process detection expects an executable name of `chrome`; if your build uses a different name, Chrome may not be closed (and files may remain locked).
 
 ## 🛟 Notes

--- a/README.zh.md
+++ b/README.zh.md
@@ -25,6 +25,15 @@
 3. 运行脚本：`uv run main.py`。
 4. 补丁过程中 Chrome 会被关闭；重启后根据提示按 Enter 结束。
 
+macOS 上可安装每周运行的 LaunchAgent，让 US 区域配置自动保持：
+
+```bash
+uv run main.py --install-persistence
+```
+
+任务会在安装后、登录时和每周日 04:00（若休眠则在下次唤醒后）检查配置；仅在区域或资格值发生漂移时重启
+Chrome。运行 `uv run main.py --remove-persistence` 可卸载。卸载只会停止后续检查，不会还原 Chrome 原有配置值。
+
 ## ⚡️ 快速开始（pip）
 1. 创建并激活虚拟环境。
 2. 安装依赖：`python -m pip install psutil`。
@@ -41,7 +50,8 @@
 ## ⚠️ 已知限制 / 注意事项
 - 脚本假设 `User Data/Local State` 已存在；若缺失可能直接失败（可先启动一次 Chrome 生成配置）。
 - 只有在能从进程信息中取到可执行文件路径时，脚本才会自动重启 Chrome。
-- macOS 上按进程名（`Google Chrome*`）识别，可能会终止不止"顶层"应用进程。
+- macOS 上只识别已知的 Chrome 顶层应用进程名，并排除 Helper 进程。
+- 持久化任务依赖当前仓库路径和 Python 环境，移动或删除后需要重新安装任务。
 - Linux 上按可执行文件名 `chrome` 识别；若你的发行版/安装方式使用其他名字，可能不会关闭 Chrome（从而仍可能有文件锁）。
 
 ## 🛟 注意

--- a/chrome_processes.py
+++ b/chrome_processes.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+import sys
+
+import psutil
+
+
+MACOS_CHROME_PROCESS_NAMES = {
+    'Google Chrome',
+    'Google Chrome Canary',
+    'Google Chrome Dev',
+    'Google Chrome Beta',
+}
+
+
+def is_top_level_chrome(process):
+    try:
+        name = process.name()
+        if sys.platform == 'darwin':
+            return name in MACOS_CHROME_PROCESS_NAMES
+        if os.path.splitext(name)[0].lower() != 'chrome':
+            return False
+
+        parent = process.parent()
+        if parent is None:
+            return True
+        return parent.name() != name
+    except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+        return False
+
+
+def shutdown_chrome():
+    executable_paths = set()
+    processes_to_wait = []
+
+    for process in psutil.process_iter():
+        if not is_top_level_chrome(process):
+            continue
+        try:
+            executable_path = process.exe()
+            children = process.children(recursive=True)
+            process.terminate()
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+
+        executable_paths.add(executable_path)
+        processes_to_wait.extend([process, *children])
+
+    _, alive = psutil.wait_procs(processes_to_wait, timeout=10)
+    for process in alive:
+        try:
+            process.kill()
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+            pass
+    if alive:
+        psutil.wait_procs(alive, timeout=5)
+
+    return executable_paths
+
+
+def chrome_restart_command(executable_path):
+    if sys.platform == 'darwin':
+        bundle_marker = '.app/'
+        if bundle_marker not in executable_path:
+            raise ValueError('Chrome executable is not inside an app bundle')
+        app_bundle = executable_path.split(bundle_marker, 1)[0] + '.app'
+        return ['open', app_bundle]
+    return [executable_path]
+
+
+def restart_chrome(executable_path):
+    subprocess.Popen(
+        chrome_restart_command(executable_path),
+        stderr=subprocess.DEVNULL,
+    )

--- a/launchd.py
+++ b/launchd.py
@@ -1,0 +1,94 @@
+import os
+import plistlib
+import subprocess
+import sys
+import tempfile
+
+
+LABEL = 'com.github.lcandy2.enable-chrome-ai'
+
+
+def launch_agent_path():
+    return os.path.expanduser('~/Library/LaunchAgents/%s.plist' % LABEL)
+
+
+def build_launch_agent(country, python_executable, script_path):
+    log_dir = os.path.expanduser('~/Library/Logs/enable-chrome-ai')
+    return {
+        'Label': LABEL,
+        'ProgramArguments': [
+            python_executable,
+            script_path,
+            '--country',
+            country,
+            '--yes',
+        ],
+        'ProcessType': 'Background',
+        'RunAtLoad': True,
+        'StartCalendarInterval': {
+            'Weekday': 0,
+            'Hour': 4,
+            'Minute': 0,
+        },
+        'StandardOutPath': os.path.join(log_dir, 'stdout.log'),
+        'StandardErrorPath': os.path.join(log_dir, 'stderr.log'),
+    }
+
+
+def _launchctl(*args, check=True):
+    return subprocess.run(
+        ['launchctl', *args],
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def install_launch_agent(country, script_path):
+    if sys.platform != 'darwin':
+        raise RuntimeError('Persistent mode currently supports macOS launchd only')
+
+    agent_path = launch_agent_path()
+    log_dir = os.path.expanduser('~/Library/Logs/enable-chrome-ai')
+    os.makedirs(os.path.dirname(agent_path), exist_ok=True)
+    os.makedirs(log_dir, exist_ok=True)
+
+    agent = build_launch_agent(
+        country=country,
+        python_executable=os.path.abspath(sys.executable),
+        script_path=os.path.realpath(script_path),
+    )
+    descriptor, temporary_path = tempfile.mkstemp(
+        prefix=LABEL + '-', suffix='.plist', dir=os.path.dirname(agent_path))
+    try:
+        with os.fdopen(descriptor, 'wb') as fp:
+            plistlib.dump(agent, fp, sort_keys=False)
+        os.replace(temporary_path, agent_path)
+    finally:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+    domain = 'gui/%d' % os.getuid()
+    _launchctl('bootout', domain, agent_path, check=False)
+    try:
+        _launchctl('bootstrap', domain, agent_path)
+    except subprocess.CalledProcessError as error:
+        message = error.stderr.strip() or error.stdout.strip()
+        raise RuntimeError('Failed to load LaunchAgent: %s' % message) from error
+
+    print('Installed %s' % agent_path)
+    print('Schedule: at login and every Sunday at 04:00 (or after the next wake)')
+    print('Country: %s' % country)
+
+
+def uninstall_launch_agent():
+    if sys.platform != 'darwin':
+        raise RuntimeError('Persistent mode currently supports macOS launchd only')
+
+    agent_path = launch_agent_path()
+    domain = 'gui/%d' % os.getuid()
+    _launchctl('bootout', domain, agent_path, check=False)
+    if os.path.exists(agent_path):
+        os.unlink(agent_path)
+    print('Removed %s' % agent_path)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
 import os
 import sys
 import json
-import subprocess
+import argparse
+import stat
+import tempfile
 
-import psutil
+from chrome_processes import restart_chrome, shutdown_chrome
+from launchd import install_launch_agent, uninstall_launch_agent
 
 
 def get_version_and_user_data_path():
@@ -40,33 +43,12 @@ def get_version_and_user_data_path():
     raise Exception('Unsupported platform %s' % sys.platform)
 
 
-def shutdown_chrome():
-    terminated_chromes = set()
-    for process in psutil.process_iter():
-        try:
-            if sys.platform == 'darwin':
-                if not process.name().startswith('Google Chrome'):
-                    continue
-            elif os.path.splitext(process.name())[0] != 'chrome':
-                continue
-            elif not process.is_running():
-                continue
-            elif process.parent() is not None and process.parent().name() == process.name():
-                continue
-            location = process.exe()
-            process.kill()
-            terminated_chromes.add(location)
-        except psutil.NoSuchProcess:
-            pass
-    return terminated_chromes
-
-
 def get_last_version(user_data_path):
     last_version_file = os.path.join(user_data_path, 'Last Version')
     if not os.path.exists(last_version_file):
         return None
     with open(last_version_file, 'r', encoding='utf-8') as fp:
-        return fp.read()
+        return fp.read().strip()
 
 
 def set_all_is_glic_eligible(obj):
@@ -74,7 +56,7 @@ def set_all_is_glic_eligible(obj):
     modified = False
     if isinstance(obj, dict):
         for key, value in obj.items():
-            if key == 'is_glic_eligible' and value != True:
+            if key == 'is_glic_eligible' and value is not True:
                 obj[key] = True
                 modified = True
             elif isinstance(value, (dict, list)):
@@ -88,7 +70,45 @@ def set_all_is_glic_eligible(obj):
     return modified
 
 
-def patch_local_state(user_data_path, last_version):
+def write_json_atomically(path, value):
+    directory = os.path.dirname(path)
+    original_mode = stat.S_IMODE(os.stat(path).st_mode)
+    descriptor, temporary_path = tempfile.mkstemp(
+        prefix='.local-state-', dir=directory)
+    try:
+        with os.fdopen(descriptor, 'w', encoding='utf-8') as fp:
+            json.dump(value, fp)
+            fp.flush()
+            os.fsync(fp.fileno())
+        os.chmod(temporary_path, original_mode)
+        os.replace(temporary_path, path)
+    finally:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+
+def local_state_needs_patch(user_data_path, last_version, country):
+    local_state_file = os.path.join(user_data_path, 'Local State')
+    if not os.path.exists(local_state_file):
+        return False
+
+    with open(local_state_file, 'r', encoding='utf-8') as fp:
+        local_state = json.load(fp)
+
+    if country is not None:
+        if local_state.get('variations_country') != country:
+            return True
+        consistency = local_state.get('variations_permanent_consistency_country')
+        if not isinstance(consistency, list) or len(consistency) < 2:
+            return True
+        if consistency[0] != last_version or consistency[1] != country:
+            return True
+
+    probe = json.loads(json.dumps(local_state))
+    return set_all_is_glic_eligible(probe)
+
+
+def patch_local_state(user_data_path, last_version, country=None):
     local_state_file = os.path.join(user_data_path, 'Local State')
     if not os.path.exists(local_state_file):
         print('Failed to patch Local State. File not found', local_state_file)
@@ -104,57 +124,108 @@ def patch_local_state(user_data_path, last_version):
         modified = True
         print('Patched is_glic_eligible')
 
-    # 2. Set variations_country to "us" (root level)
-    if local_state.get('variations_country') != 'us':
-        local_state['variations_country'] = 'us'
-        modified = True
-        print('Patched variations_country')
+    # Use the requested variations country (defaults to "us").
+    if country is not None:
+        # 2. Set variations_country (root level)
+        if local_state.get('variations_country') != country:
+            local_state['variations_country'] = country
+            modified = True
+            print('Patched variations_country -> %s' % country)
 
-    # 3. Set variations_permanent_consistency_country[0] to last_version, [1] to "us" (root level)
-    if 'variations_permanent_consistency_country' in local_state:
-        if isinstance(local_state['variations_permanent_consistency_country'], list) and \
-           len(local_state['variations_permanent_consistency_country']) >= 2:
-            if local_state['variations_permanent_consistency_country'][0] != last_version or \
-               local_state['variations_permanent_consistency_country'][1] != 'us':
-                local_state['variations_permanent_consistency_country'][0] = last_version
-                local_state['variations_permanent_consistency_country'][1] = 'us'
-                modified = True
-                print('Patched variations_permanent_consistency_country')
+        # 3. Set variations_permanent_consistency_country[0] to last_version, [1] to country
+        consistency = local_state.get('variations_permanent_consistency_country')
+        if not isinstance(consistency, list) or len(consistency) < 2:
+            local_state['variations_permanent_consistency_country'] = [last_version, country]
+            modified = True
+            print('Created variations_permanent_consistency_country -> %s' % country)
+        elif consistency[0] != last_version or consistency[1] != country:
+            consistency[0] = last_version
+            consistency[1] = country
+            modified = True
+            print('Patched variations_permanent_consistency_country -> %s' % country)
+    else:
+        print('Kept variations_country as-is (%s); pass --country to override'
+              % local_state.get('variations_country'))
 
     if modified:
-        with open(local_state_file, 'w', encoding='utf-8') as fp:
-            json.dump(local_state, fp)
+        write_json_atomically(local_state_file, local_state)
         print('Succeeded in patching Local State')
     else:
         print('No need to patch Local State')
 
 
+def parse_country(value):
+    country = value.lower()
+    if len(country) != 2 or not country.isascii() or not country.isalpha():
+        raise argparse.ArgumentTypeError('country must be a two-letter code')
+    return country
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Enable Chrome's built-in AI by patching the local profile.")
+    parser.add_argument(
+        '--country', default='us', type=parse_country, metavar='CC',
+        help='Set variations country (default: us; e.g. us, sg).')
+    parser.add_argument(
+        '-y', '--yes', action='store_true',
+        help='Run non-interactively (skip the final Enter prompt). For launchd/cron.')
+    persistence = parser.add_mutually_exclusive_group()
+    persistence.add_argument(
+        '--install-persistence', action='store_true',
+        help='Install a macOS LaunchAgent that repairs country drift.')
+    persistence.add_argument(
+        '--remove-persistence', action='store_true',
+        help='Unload and remove the macOS LaunchAgent.')
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
+
+    if args.install_persistence:
+        install_launch_agent(args.country, __file__)
+        return
+    if args.remove_persistence:
+        uninstall_launch_agent()
+        return
+
     version_and_user_data_path = get_version_and_user_data_path()
     if len(version_and_user_data_path) == 0:
         raise Exception('No available user data path found')
 
-    terminated_chromes = shutdown_chrome()
-    if len(terminated_chromes) > 0:
-        print('Shutdown Chrome')
-
+    pending = {}
     for version, user_data_path in version_and_user_data_path.items():
         last_version = get_last_version(user_data_path)
         if last_version is None:
             print('Failed to get version. File not found', os.path.join(user_data_path, 'Last Version'))
             continue
-        main_version = int(last_version.split('.')[0])
-        print('Patching Chrome', version, last_version, '"'+user_data_path+'"')
-        patch_local_state(user_data_path, last_version)
+        if local_state_needs_patch(user_data_path, last_version, args.country):
+            pending[version] = (last_version, user_data_path)
 
+    if not pending:
+        print('All Chrome profiles already match country %s' % args.country)
+        if not args.yes:
+            input('Enter to continue...')
+        return
+
+    terminated_chromes = shutdown_chrome()
     if len(terminated_chromes) > 0:
-        print('Restart Chrome')
-        for chrome in terminated_chromes:
-            subprocess.Popen([chrome], stderr=subprocess.DEVNULL)
+        print('Shutdown Chrome')
 
-    input('Enter to continue...')
+    try:
+        for version, (last_version, user_data_path) in pending.items():
+            print('Patching Chrome', version, last_version, '"'+user_data_path+'"')
+            patch_local_state(user_data_path, last_version, country=args.country)
+    finally:
+        if len(terminated_chromes) > 0:
+            print('Restart Chrome')
+            for chrome in terminated_chromes:
+                restart_chrome(chrome)
+
+    if not args.yes:
+        input('Enter to continue...')
 
 
 if __name__ == '__main__':
     main()
-

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,203 @@
+import json
+import os
+import plistlib
+import stat
+import sys
+import tempfile
+import unittest
+from argparse import Namespace
+from unittest import mock
+
+import chrome_processes
+import launchd
+import main
+from launchd import build_launch_agent
+
+
+class PersistenceTests(unittest.TestCase):
+    def make_local_state(self, value):
+        temporary_directory = tempfile.TemporaryDirectory()
+        path = os.path.join(temporary_directory.name, 'Local State')
+        with open(path, 'w', encoding='utf-8') as fp:
+            json.dump(value, fp)
+        return temporary_directory, path
+
+    def test_missing_consistency_is_created(self):
+        directory, path = self.make_local_state({
+            'variations_country': 'us',
+            'is_glic_eligible': True,
+        })
+        self.addCleanup(directory.cleanup)
+
+        self.assertTrue(main.local_state_needs_patch(directory.name, '150', 'us'))
+        main.patch_local_state(directory.name, '150', 'us')
+
+        with open(path, 'r', encoding='utf-8') as fp:
+            state = json.load(fp)
+        self.assertEqual(
+            state['variations_permanent_consistency_country'], ['150', 'us'])
+        self.assertFalse(main.local_state_needs_patch(directory.name, '150', 'us'))
+
+    def test_atomic_write_preserves_permissions(self):
+        directory, path = self.make_local_state({'old': True})
+        self.addCleanup(directory.cleanup)
+        os.chmod(path, 0o600)
+
+        main.write_json_atomically(path, {'new': True})
+
+        with open(path, 'r', encoding='utf-8') as fp:
+            self.assertEqual(json.load(fp), {'new': True})
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o600)
+
+    def test_failed_atomic_write_keeps_original_file(self):
+        directory, path = self.make_local_state({'old': True})
+        self.addCleanup(directory.cleanup)
+
+        with mock.patch('main.json.dump', side_effect=OSError('disk full')):
+            with self.assertRaisesRegex(OSError, 'disk full'):
+                main.write_json_atomically(path, {'new': True})
+
+        with open(path, 'r', encoding='utf-8') as fp:
+            self.assertEqual(json.load(fp), {'old': True})
+        self.assertEqual(os.listdir(directory.name), ['Local State'])
+
+    def test_country_is_normalized_and_validated(self):
+        self.assertEqual(main.parse_country('US'), 'us')
+        with self.assertRaisesRegex(Exception, 'two-letter'):
+            main.parse_country('usa')
+
+    @unittest.skipUnless(sys.platform == 'darwin', 'macOS-specific command')
+    def test_restart_uses_launch_services(self):
+        executable = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        self.assertEqual(
+            chrome_processes.chrome_restart_command(executable),
+            ['open', '/Applications/Google Chrome.app'],
+        )
+
+    def test_launch_agent_is_fixed_to_country_and_runs_at_login(self):
+        agent = build_launch_agent('us', '/venv/python', '/repo/main.py')
+        plistlib.loads(plistlib.dumps(agent))
+        self.assertEqual(
+            agent['ProgramArguments'],
+            ['/venv/python', '/repo/main.py', '--country', 'us', '--yes'],
+        )
+        self.assertTrue(agent['RunAtLoad'])
+
+    @mock.patch('launchd.sys.platform', 'darwin')
+    @mock.patch('launchd._launchctl')
+    def test_launch_agent_install_is_loadable(self, launchctl):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+
+        with mock.patch.dict(os.environ, {'HOME': directory.name}):
+            launchd.install_launch_agent('us', '/repo/main.py')
+            agent_path = launchd.launch_agent_path()
+            with open(agent_path, 'rb') as fp:
+                agent = plistlib.load(fp)
+
+        self.assertEqual(agent['Label'], launchd.LABEL)
+        self.assertEqual(agent['ProgramArguments'][-3:], ['--country', 'us', '--yes'])
+        domain = 'gui/%d' % os.getuid()
+        self.assertEqual(
+            launchctl.call_args_list,
+            [
+                mock.call('bootout', domain, agent_path, check=False),
+                mock.call('bootstrap', domain, agent_path),
+            ],
+        )
+
+    @mock.patch('chrome_processes.psutil.wait_procs', return_value=([], []))
+    @mock.patch('chrome_processes.psutil.process_iter')
+    def test_shutdown_ignores_chrome_helpers(self, process_iter, wait_procs):
+        helper = mock.Mock()
+        helper.name.return_value = 'Google Chrome Helper'
+        process_iter.return_value = [helper]
+
+        self.assertEqual(chrome_processes.shutdown_chrome(), set())
+        helper.terminate.assert_not_called()
+        wait_procs.assert_called_once_with([], timeout=10)
+
+    @mock.patch('chrome_processes.sys.platform', 'win32')
+    def test_parent_disappearing_does_not_crash(self):
+        process = mock.Mock()
+        process.name.return_value = 'chrome.exe'
+        process.parent.side_effect = chrome_processes.psutil.NoSuchProcess(123)
+
+        self.assertFalse(chrome_processes.is_top_level_chrome(process))
+
+    @mock.patch('chrome_processes.sys.platform', 'win32')
+    def test_parentless_windows_process_is_top_level(self):
+        process = mock.Mock()
+        process.name.return_value = 'chrome.exe'
+        process.parent.return_value = None
+
+        self.assertTrue(chrome_processes.is_top_level_chrome(process))
+
+    @mock.patch('chrome_processes.sys.platform', 'darwin')
+    @mock.patch('chrome_processes.psutil.wait_procs')
+    @mock.patch('chrome_processes.psutil.process_iter')
+    def test_shutdown_waits_for_main_process_and_children(
+            self, process_iter, wait_procs):
+        chrome = mock.Mock()
+        chrome.name.return_value = 'Google Chrome'
+        chrome.exe.return_value = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        child = mock.Mock()
+        chrome.children.return_value = [child]
+        process_iter.return_value = [chrome]
+        wait_procs.return_value = ([chrome, child], [])
+
+        self.assertEqual(
+            chrome_processes.shutdown_chrome(),
+            {'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'},
+        )
+        chrome.terminate.assert_called_once_with()
+        wait_procs.assert_called_once_with([chrome, child], timeout=10)
+
+    @mock.patch('chrome_processes.sys.platform', 'darwin')
+    @mock.patch('chrome_processes.psutil.wait_procs')
+    @mock.patch('chrome_processes.psutil.process_iter')
+    def test_shutdown_kills_process_after_timeout(
+            self, process_iter, wait_procs):
+        chrome = mock.Mock()
+        chrome.name.return_value = 'Google Chrome'
+        chrome.exe.return_value = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        chrome.children.return_value = []
+        process_iter.return_value = [chrome]
+        wait_procs.side_effect = [([], [chrome]), ([chrome], [])]
+
+        chrome_processes.shutdown_chrome()
+
+        chrome.kill.assert_called_once_with()
+        self.assertEqual(
+            wait_procs.call_args_list,
+            [
+                mock.call([chrome], timeout=10),
+                mock.call([chrome], timeout=5),
+            ],
+        )
+
+    @mock.patch('chrome_processes.sys.platform', 'darwin')
+    def test_macos_restart_rejects_non_bundle_executable(self):
+        with self.assertRaisesRegex(ValueError, 'app bundle'):
+            chrome_processes.chrome_restart_command('/usr/local/bin/chrome')
+
+    @mock.patch('main.restart_chrome')
+    @mock.patch('main.patch_local_state', side_effect=OSError('disk full'))
+    @mock.patch('main.shutdown_chrome', return_value={'/path/to/chrome'})
+    @mock.patch('main.local_state_needs_patch', return_value=True)
+    @mock.patch('main.get_last_version', return_value='150')
+    @mock.patch('main.get_version_and_user_data_path', return_value={'stable': '/profile'})
+    @mock.patch('main.parse_args', return_value=Namespace(
+        country='us', yes=True,
+        install_persistence=False, remove_persistence=False))
+    def test_patch_failure_still_restarts_chrome(
+            self, _parse_args, _paths, _version, _needs_patch,
+            _shutdown, _patch, restart):
+        with self.assertRaisesRegex(OSError, 'disk full'):
+            main.main()
+
+        restart.assert_called_once_with('/path/to/chrome')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
> Draft RFC: I am looking for feedback on the macOS scheduling approach before marking this ready for merge.

Chrome can replace `variations_country` after an update or a new variations seed. Running the script again fixes it, but that currently requires manual intervention.

This change adds an optional macOS LaunchAgent. It checks the configuration after installation, at login, and every Sunday at 04:00. The job exits without touching Chrome when the country and eligibility values are already correct.

The patch also fixes two problems in the existing restart path:

- macOS now reopens the `.app` bundle through LaunchServices instead of starting the executable directly.
- Chrome and its child processes are given time to exit before `Local State` is changed. Remaining processes are killed after the timeout.

`Local State` is written through a temporary file and replaced atomically. Chrome is reopened in a `finally` block if patching fails.

### Commands

```bash
uv run main.py --install-persistence
uv run main.py --remove-persistence
```

The country defaults to `us`. `--country CC` accepts another two-letter country code.

Removing the LaunchAgent stops future checks. It does not restore the previous Chrome values.

### Validation

```text
uv run python -m unittest discover -s tests -q
Ran 14 tests: OK

uvx ruff check .
All checks passed!

uv run python -m py_compile main.py launchd.py chrome_processes.py tests/test_persistence.py
git diff --check
```

The LaunchAgent was also loaded and run on macOS 27.0 (26A5378n) with Chrome 150.0.7871.129. It exited with status 0, and the no-change path left the running Chrome process untouched.

Related: #23 and #25.

Backup and restore remain outside this patch and are tracked in #8. The broader Glic preference changes from #28 are also left unchanged.
