### PR TITLE
fix: reliably restart Chrome on macOS

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,8 +167,10 @@ def main():
         print('Restart Chrome')
         for chrome in terminated_chromes:
             if sys.platform == 'darwin':
-                # 用 open -a 走 LaunchServices 拉起：直接 exec 内部二进制在更新期会变成
-                # code_sign_clone 临时副本导致静默失败，且不会把窗口带到前台。
+                # Relaunch through LaunchServices ("open -a"): exec'ing the internal
+                # binary directly resolves to the code_sign_clone temporary copy
+                # during an auto-update and fails silently, and it never brings
+                # the window to the foreground.
                 subprocess.Popen(['open', '-a', os.path.basename(chrome)], stderr=subprocess.DEVNULL)
             else:
                 subprocess.Popen([chrome], stderr=subprocess.DEVNULL)

--- a/main.py
+++ b/main.py
@@ -41,22 +41,38 @@ def get_version_and_user_data_path():
 
 
 def shutdown_chrome():
+    """Kill all Chrome processes; return only the main browser executables to relaunch."""
     terminated_chromes = set()
     for process in psutil.process_iter():
         try:
+            name = process.name()
+
             if sys.platform == 'darwin':
-                if not process.name().startswith('Google Chrome'):
-                    continue
-            elif os.path.splitext(process.name())[0] != 'chrome':
+                # 主浏览器 + helper 都以 "Google Chrome" 开头。
+                is_chrome = name.startswith('Google Chrome')
+                is_main_browser = is_chrome and 'Helper' not in name
+                # crashpad 进程名 "chrome_crashpad_handler" 与 Electron 应用（WorkBuddy、
+                # CodeBuddy 等）同名，必须用可执行文件路径确认它确实属于 Google Chrome。
+                if not is_chrome and name.startswith('chrome_crashpad'):
+                    is_chrome = 'Google Chrome' in process.exe()
+            else:
+                is_chrome = os.path.splitext(name)[0] == 'chrome'
+                # 主浏览器是其父进程不是另一个 chrome 的顶层进程（保留原脚本语义）。
+                is_main_browser = is_chrome and (
+                    process.parent() is None or process.parent().name() != name
+                )
+
+            if not is_chrome:
                 continue
-            elif not process.is_running():
-                continue
-            elif process.parent() is not None and process.parent().name() == process.name():
-                continue
-            location = process.exe()
+
+            # 先取 exe 路径再 kill：kill 之后进程可能变成僵尸态取不到 exe。
+            location = process.exe() if is_main_browser else None
             process.kill()
-            terminated_chromes.add(location)
-        except psutil.NoSuchProcess:
+
+            # 只重启主浏览器。裸启动 Helper / crashpad 子进程会产生孤儿进程，导致 Chrome 卡死。
+            if is_main_browser:
+                terminated_chromes.add(location)
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             pass
     return terminated_chromes
 
@@ -150,7 +166,12 @@ def main():
     if len(terminated_chromes) > 0:
         print('Restart Chrome')
         for chrome in terminated_chromes:
-            subprocess.Popen([chrome], stderr=subprocess.DEVNULL)
+            if sys.platform == 'darwin':
+                # 用 open -a 走 LaunchServices 拉起：直接 exec 内部二进制在更新期会变成
+                # code_sign_clone 临时副本导致静默失败，且不会把窗口带到前台。
+                subprocess.Popen(['open', '-a', os.path.basename(chrome)], stderr=subprocess.DEVNULL)
+            else:
+                subprocess.Popen([chrome], stderr=subprocess.DEVNULL)
 
     input('Enter to continue...')
 


### PR DESCRIPTION
## Problem

On macOS, after the script patches `Local State` and kills Chrome, Chrome fails to restart reliably. In some cases it doesn't come back at all — e.g. when the kill happens while Chrome is auto-updating (the main binary then runs from a `code_sign_clone` temporary path under `/private/var/folders/...`).

## Root causes

Three issues in `shutdown_chrome()` and the relaunch logic:

1. **Incomplete kill**: helper processes and the `chrome_crashpad_handler` were not killed, leaving zombie processes and stale `SingletonLock` files that block the next launch.
2. **Naive crashpad matching**: matching by process name alone would also kill the crashpad handlers of Electron apps, since they share the same process name `chrome_crashpad_handler`.
3. **Fragile relaunch**: `subprocess.Popen([<internal binary>])` execs the internal binary directly — during a Chrome auto-update this path is a temporary `code_sign_clone` copy that fails silently, and even when it works it does not bring the window to the foreground.

## Fix

- Kill all Chrome processes: the main browser plus every `Google Chrome Helper*` process; for `chrome_crashpad_handler`, verify the exe path actually belongs to Google Chrome before killing, so Electron apps' crashpad handlers are left alone.
- Capture the exe path **before** `kill()` (after the kill, the process may become a zombie and `exe()` raises).
- Relaunch via `open -a <AppName>` (LaunchServices) on macOS instead of exec'ing the internal binary — this survives the auto-update temporary-path case and brings the window to the foreground.
- On non-macOS platforms, keep the original "skip child processes" semantics when picking the main executable to relaunch.

## Testing

Verified manually on macOS, including the Chrome 151 -> 152 auto-update scenario:

- 43 Chrome processes (browser + helpers + crashpad) correctly identified and killed; Electron apps' crashpad handlers untouched.
- Chrome relaunches reliably with the window in the foreground, including right after an auto-update.